### PR TITLE
Rename class_name option to resource_class

### DIFF
--- a/lib/json_api_ruby/resources/base.rb
+++ b/lib/json_api_ruby/resources/base.rb
@@ -8,7 +8,7 @@ module JsonApi
         options.symbolize_keys
 
         resource_hash = identifier_hash
-        resource_hash['attributes'] = attributes_hash
+        resource_hash['attributes'] = attributes_hash if attributes_hash.any?
 
         relationships.each do |relationship|
           resource_hash['relationships'] ||= {}
@@ -40,7 +40,7 @@ module JsonApi
 
       def attributes_hash
         attrs = {}
-        self.class.fields.each do |attr|
+        Array(self.class.fields).each do |attr|
           attrs[attr.to_s] = send(attr)
         end
         attrs

--- a/lib/json_api_ruby/serializer.rb
+++ b/lib/json_api_ruby/serializer.rb
@@ -21,15 +21,15 @@ module JsonApi
 
   class Serializer
     def initialize(object, options)
-      @meta         = options.fetch('meta', Hash.new).stringify_keys
-      @object       = object
-      @includes     = options.fetch('include', [])
-      resource_name = "#{@object.class.to_s.underscore}_resource".classify
-      @klass_name   = options.fetch('class_name', resource_name)
+      @meta           = options.fetch('meta', Hash.new).stringify_keys
+      @object         = object
+      @includes       = options.fetch('include', [])
+      resource_name   = "#{@object.class.to_s.underscore}_resource".classify
+      @resource_class = options.fetch('resource_class', resource_name)
     end
 
     def to_hash
-      resource_klass = Resources::Discovery.resource_for_name(@object, resource_class: @klass_name)
+      resource_klass = Resources::Discovery.resource_for_name(@object, resource_class: @resource_class)
       resource       = resource_klass.new(@object, include: @includes)
       serialized     = { 'data' => resource.to_hash }
       relationships  = resource.relationships
@@ -56,10 +56,10 @@ module JsonApi
 
   class CollectionSerializer
     def initialize(objects, options = {})
-      @meta     = options.fetch('meta', Hash.new).stringify_keys
-      @objects  = objects
-      @includes = options.fetch('include', [])
-      @klass_name   = options.fetch('class_name', nil)
+      @meta           = options.fetch('meta', Hash.new).stringify_keys
+      @objects        = objects
+      @includes       = options.fetch('include', [])
+      @resource_class = options.fetch('resource_class', nil)
     end
 
     def to_hash
@@ -67,10 +67,10 @@ module JsonApi
       included_data = []
 
       data_array = @objects.map do |object|
-        resource_name = "#{object.class.to_s.underscore}_resource".classify
-        klass_name   = @klass_name || resource_name
+        resource_name  = "#{object.class.to_s.underscore}_resource".classify
+        klass_name     = @resource_class || resource_name
         resource_klass = Resources::Discovery.resource_for_name(object, resource_class: klass_name)
-        resource = resource_klass.new(object, include: @includes)
+        resource       = resource_klass.new(object, include: @includes)
         included_data += assemble_included_data(resource.relationships)
         resource.to_hash
       end
@@ -97,4 +97,3 @@ module JsonApi
     end
   end
 end
-

--- a/spec/json_api_ruby/serializer_spec.rb
+++ b/spec/json_api_ruby/serializer_spec.rb
@@ -10,12 +10,22 @@ RSpec.describe JsonApi::Serializer do
       JsonApi.serialize(person, meta: { meta_key: 'meta value' })
     end
 
+    subject(:serialized_data_other_resource_class) do
+      JsonApi.serialize(person, resource_class: 'Namespace::OneResource')
+    end
+
     it 'has a top level data object' do
       expect(serialized_data).to have_data
     end
 
     it 'passes meta through' do
       expect(serialized_data).to have_meta
+    end
+
+    it 'serializes the data using the passed-in resource class' do
+      expected_keys = %w(id type links)
+      expect(serialized_data_other_resource_class['data']).to be_valid_json_api
+      expect(serialized_data_other_resource_class['data'].keys).to eql(expected_keys)
     end
 
     context 'with included resources' do
@@ -42,6 +52,18 @@ RSpec.describe JsonApi::Serializer do
         Person.new('Sabastian Bludd', 'sbludd@cobra.mil'),
         Person.new('John Zullo', 'ace@specops.mil')
       ]
+    end
+
+    subject(:serialized_collection_other_resource_class) do
+      JsonApi.serialize(people, resource_class: 'Namespace::OneResource')
+    end
+
+    it 'serializes the data using the passed-in resource class' do
+      serialized_collection_other_resource_class['data'].each do |serialized|
+        expected_keys = %w(id type links)
+        expect(serialized).to be_valid_json_api
+        expect(serialized.keys).to eql(expected_keys)
+      end
     end
 
     context 'without included resources' do


### PR DESCRIPTION
@teubanks this is just for consistency. `resource_class` is exposed to a `Resource` as an option when defining relationships, but `class_name` is exposed as an option to `JsonApi.serialize`. This brings the two together.