### PR TITLE
fix for passing relationship options to discovery.resource_for_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ pkg
 /test/version_tmp/
 /tmp/
 
+## Specific to RubyMine
+.idea
+
 ## Specific to RubyMotion:
 .dat*
 .repl_history
@@ -31,8 +34,8 @@ build/
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
 # Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+.ruby-version
+.ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc


### PR DESCRIPTION
Feel free to clean it up, but this fixes one of the issues I was running into