### PR TITLE
Add ability to subclass a class whose superclass is Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.2.0
+Added the ability to subclass from a class whose superclass is Resource
+
 0.1.1
 Fix issues related to empty or nil objects
 

--- a/lib/json_api_ruby/resources/base.rb
+++ b/lib/json_api_ruby/resources/base.rb
@@ -54,17 +54,11 @@ module JsonApi
         end
       end
 
-      private
-
       # Traverses fields set on super-class(es) and concatinates them into a
       # single set. Stores the set in `self.class.fields`, leaving super-class
       # `fields` sets untouched.
       def fields_array(klass = self.class)
-        fields_list = Array(self.class.fields)
-        not_in_list = Array(klass.fields).reject do |field|
-          fields_list.include?(field)
-        end
-        not_in_list.each { |field| fields_list << field }
+        fields_list = concat_list(self.class.fields, klass.fields)
         unless klass.superclass == Resource
           return fields_array(klass.superclass)
         end
@@ -75,15 +69,24 @@ module JsonApi
       # into a single set. Stores the set in `self.class.relationships`,
       # leaving super-class `relationships` sets untouched.
       def relationships_array(klass = self.class)
-        rel_list = Array(self.class.relationships)
-        not_in_list = Array(klass.relationships).reject do |rel|
-          rel_list.include?(rel)
-        end
-        not_in_list.each { |rel| rel_list << rel }
+        rel_list = concat_list(self.class.relationships, klass.relationships)
         unless klass.superclass == Resource
           return relationships_array(klass.superclass)
         end
         rel_list
+      end
+
+      private
+
+      # Adds elements of the `concat_list` to the `target_list` if they are
+      # not already present.
+      def concat_list(target_list, concat_list)
+        list = Array(target_list)
+        not_in_list = Array(concat_list).reject do |item|
+          list.include?(item)
+        end
+        not_in_list.each { |item| list << item }
+        list
       end
     end
 

--- a/lib/json_api_ruby/resources/base.rb
+++ b/lib/json_api_ruby/resources/base.rb
@@ -37,7 +37,7 @@ module JsonApi
       end
 
       def attributes_hash
-        Array(self.class.fields).inject({}) do |attrs, attr|
+        fields_array.inject({}) do |attrs, attr|
           meth = method(attr)
           attrs[attr.to_s] = meth.call
           attrs
@@ -47,11 +47,43 @@ module JsonApi
       # Builds relationship resource classes
       def build_object_graph
         @relationships ||= []
-        Array(self.class.relationships).each do |relationship|
+        relationships_array.each do |relationship|
           included = includes.include?(relationship.name)
           rel = relationship.build_resources({parent_resource: self, included: included})
           @relationships << rel
         end
+      end
+
+      private
+
+      # Traverses fields set on super-class(es) and concatinates them into a
+      # single set. Stores the set in `self.class.fields`, leaving super-class
+      # `fields` sets untouched.
+      def fields_array(klass = self.class)
+        fields_list = Array(self.class.fields)
+        not_in_list = Array(klass.fields).reject do |field|
+          fields_list.include?(field)
+        end
+        not_in_list.each { |field| fields_list << field }
+        unless klass.superclass == Resource
+          return fields_array(klass.superclass)
+        end
+        fields_list
+      end
+
+      # Traverses relationships set on super-class(es) and concatinates them
+      # into a single set. Stores the set in `self.class.relationships`,
+      # leaving super-class `relationships` sets untouched.
+      def relationships_array(klass = self.class)
+        rel_list = Array(self.class.relationships)
+        not_in_list = Array(klass.relationships).reject do |rel|
+          rel_list.include?(rel)
+        end
+        not_in_list.each { |rel| rel_list << rel }
+        unless klass.superclass == Resource
+          return relationships_array(klass.superclass)
+        end
+        rel_list
       end
     end
 

--- a/lib/json_api_ruby/version.rb
+++ b/lib/json_api_ruby/version.rb
@@ -1,3 +1,3 @@
 module JsonApi
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/spec/support/resource_objects.rb
+++ b/spec/support/resource_objects.rb
@@ -53,11 +53,13 @@ end
 
 class Person
   include Identifiers
-  attr_accessor :name, :email_address, :created_at, :updated_at
+  attr_accessor :name, :email_address, :website, :twitter, :created_at, :updated_at
 
-  def initialize(name, email)
+  def initialize(name, email, website = nil, twitter = nil)
     @name = name
     @email_address = email
+    @website = website
+    @twitter = twitter
     @created_at = 1.month.ago
     @updated_at = 1.month.ago
   end
@@ -74,6 +76,26 @@ class PersonResource < JsonApi::Resource
   attribute :updated_at
 
   has_many :articles
+end
+
+class SubclassedPersonResource < PersonResource
+  attribute :website
+end
+
+class DeeplySubclassedPersonResource < SubclassedPersonResource
+  attribute :twitter
+end
+
+class OverriddenSubclassedPersonResource < PersonResource
+  def name
+    object.name + '!!'
+  end
+end
+
+class OverriddenDeeplySubclassedPersonResource < OverriddenSubclassedPersonResource
+  def name
+    object.name + '?'
+  end
 end
 
 class ArticleResource < JsonApi::Resource
@@ -127,4 +149,3 @@ module DifferentNamespace
   class ThreeResource < JsonApi::Resource
   end
 end
-


### PR DESCRIPTION
In a Rails STI model (or any other model that inherits from another model), you may want a Resource for each subclass. This change allows you to define a Resource than inherits from a Resource you've already defined, like so: 

```ruby 
class ConfigResource < JsonApi::Resource 
  attribute :name
  attribute :value 

  has_one :user
end

class DisplayConfigResource < ConfigResource 
end
```

The attributes and relationship lists built by the `ConfigResource` class will be automagically concatinated into the attributes and relationship lists built by its subclasses. Attributes and relationships added only to subclasses will be respected and added to the super-class attributes and relationships. 