### PR TITLE
Fix issue with deeply subclassed Resources and their _id_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.2.1
+Fix issues with `_id_field` on subclasses of class whose superclass is Resource
+
 0.2.0
 Added the ability to subclass from a class whose superclass is Resource
 

--- a/lib/json_api_ruby/resources/base.rb
+++ b/lib/json_api_ruby/resources/base.rb
@@ -25,7 +25,7 @@ module JsonApi
       end
 
       def identifier_hash
-        { 'id' =>  self.id, 'type' =>  self.type }
+        { 'id' => _model.send(id_field), 'type' =>  self.type }
       end
 
       def links_hash
@@ -77,6 +77,17 @@ module JsonApi
       end
 
       private
+
+      # Traverses superclasses for the first `_id_field` not set to `:id` and
+      # return its value. Stops when the superclass is Resource.
+      def id_field(klass = self.class)
+        return klass._id_field unless klass._id_field == :id
+        if klass.superclass == Resource
+          klass._id_field
+        else
+          id_field(klass.superclass)
+        end
+      end
 
       # Adds elements of the `concat_list` to the `target_list` if they are
       # not already present.

--- a/lib/json_api_ruby/version.rb
+++ b/lib/json_api_ruby/version.rb
@@ -1,3 +1,3 @@
 module JsonApi
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/json_api_ruby/resource_spec.rb
+++ b/spec/json_api_ruby/resource_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe JsonApi::Resource do
         SubclassedPersonResource.new(person).to_hash
       end
 
+      it 'can override the id field of its super-class' do
+        expect(subclass_serialization['id']).to eq('Philip J. Fry')
+      end
+
       it "does not affect its super-class's list of attributes" do
         expect(PersonResource.fields).to_not eq(SubclassedPersonResource.fields)
       end
@@ -109,7 +113,9 @@ RSpec.describe JsonApi::Resource do
       end
 
       it 'returns the same relationships as its super-class' do
-        expect(subclass_serialization['relationships']).to eq(super_class_serialization['relationships'])
+        actual_relationship_names = subclass_serialization['relationships'].keys
+        expected_relationship_names = super_class_serialization['relationships'].keys
+        expect(actual_relationship_names).to eq(expected_relationship_names)
       end
 
       context 'with overridden attributes' do
@@ -126,6 +132,10 @@ RSpec.describe JsonApi::Resource do
     context 'subclasses of subclasses of class whose superclass is Resource' do
       subject(:deep_subclass_serialization) do
         DeeplySubclassedPersonResource.new(person).to_hash
+      end
+
+      it 'can fall back to the id of its super-class' do
+        expect(deep_subclass_serialization['id']).to eq('Philip J. Fry')
       end
 
       it 'concatinates its attributes with the list of attributes from its super-classes' do

--- a/spec/support/resource_objects.rb
+++ b/spec/support/resource_objects.rb
@@ -79,6 +79,7 @@ class PersonResource < JsonApi::Resource
 end
 
 class SubclassedPersonResource < PersonResource
+  id_field :name
   attribute :website
 end
 


### PR DESCRIPTION
This fixes an issue where a deeply subclassed Resource object would not respect the `id_field` of its superclasses. This results in unexpected behavior for the subclass, since its `id_field` is set to `:id`. 