### PR TITLE
Add cardinality method to Relationship subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.3.0
+Added `cardinality` instance method to `ToManyRelationship` and `ToOneRelationship`
+
 0.2.2
 Fix issues with `id_field` returning a string and not supporting method overriding
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_api_ruby (0.2.1)
+    json_api_ruby (0.3.0)
       activesupport (~> 3)
 
 GEM

--- a/lib/json_api_ruby/resources/relationships.rb
+++ b/lib/json_api_ruby/resources/relationships.rb
@@ -103,6 +103,10 @@ module JsonApi
       def resource_object
         @resources.first
       end
+
+      def cardinality
+        :one
+      end
     end
 
     class ToManyRelationship < Relationship
@@ -125,6 +129,10 @@ module JsonApi
 
       def resource_objects
         @resources
+      end
+
+      def cardinality
+        :many
       end
     end
   end

--- a/lib/json_api_ruby/version.rb
+++ b/lib/json_api_ruby/version.rb
@@ -1,3 +1,3 @@
 module JsonApi
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end

--- a/spec/json_api_ruby/resources/relationships_spec.rb
+++ b/spec/json_api_ruby/resources/relationships_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe JsonApi::Resources::RelationshipMeta do
     end
   end
 
+  it 'exposes its cardinality' do
+    expect(author_relation.cardinality).to eq :one
+    expect(comments_relation.cardinality).to eq :many
+  end
+
   describe 'link serialization' do
     subject(:links_object) do
       rel = author_relation.build_resources(parent_resource: article_resource)


### PR DESCRIPTION
Simple convenience method `cardinality` that returns a symbol indicating the relationship's cardinality.