### PR TITLE
Fixed an issue with duplicate data in the included array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.2
+Fixed an issue where serializing a collection with `include` options could result in duplicate
+data returned in the `included` key
+
 0.4.1
 Some major refactoring but no backwards compatibility breaking functionality
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_api_ruby (0.3.0)
+    json_api_ruby (0.4.2)
       activesupport (~> 3)
 
 GEM

--- a/lib/json_api_ruby/serializer.rb
+++ b/lib/json_api_ruby/serializer.rb
@@ -44,7 +44,12 @@ module JsonApi
       included_resources = object_resource.relationships.select {|rel| rel.included?}.flat_map {|rel| rel.resources }
       included_resources += included_resources.flat_map {|res| find_included_resources(res) }
       included_resources.flatten
-      included_resources.uniq { |rel| rel.id + rel.type }
+      unique_identifiers!(included_resources)
+    end
+
+    def unique_identifiers!(resources)
+      resources.uniq! { |rel| rel.id + rel.type }
+      resources
     end
   end
 
@@ -74,6 +79,7 @@ module JsonApi
       data_array = Array(@object).map do |object|
         object_resource = resource(object)
         included_resources += find_included_resources(object_resource)
+        unique_identifiers!(included_resources)
         object_resource.to_hash
       end
 

--- a/lib/json_api_ruby/version.rb
+++ b/lib/json_api_ruby/version.rb
@@ -1,3 +1,3 @@
 module JsonApi
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/json_api_ruby/serializer_spec.rb
+++ b/spec/json_api_ruby/serializer_spec.rb
@@ -99,6 +99,8 @@ RSpec.describe JsonApi::Serializer do
 
     context 'with included resources' do
       subject(:serialized_resources) do
+        people.first.articles << people.second.articles.first
+        people.second.articles << people.first.articles.first
         JsonApi.serialize(people, meta: {'I' => 'have meta'}, include: [:articles])
       end
 


### PR DESCRIPTION
This occurs when serializing a collection whose members share
a common included record.