### PR TITLE
Add support for hash-based include arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.4
+Adds support for passing a hash-based argument list to `include`, matching the
+interface of ActiveRecord::QueryMethods#includes.
+
 0.4.3
 Removed the constraint on activesupport 3. Should be >= 3 not ~> 3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,18 @@
 PATH
   remote: .
   specs:
-    json_api_ruby (0.4.3)
+    json_api_ruby (0.4.4)
       activesupport (>= 3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.1)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (4.2.3)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     byebug (8.2.1)
     coderay (1.1.0)
     diff-lcs (1.2.5)
@@ -30,12 +33,13 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     i18n (0.7.0)
+    json (1.8.3)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.10)
     method_source (0.8.2)
-    multi_json (1.11.2)
+    minitest (5.7.0)
     nenv (0.2.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -69,6 +73,9 @@ GEM
     shellany (0.0.1)
     slop (3.6.0)
     thor (0.19.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/lib/json_api_ruby/includes.rb
+++ b/lib/json_api_ruby/includes.rb
@@ -10,7 +10,14 @@ module JsonApi
     def self.parse_includes(includes)
       first_include = self.new
 
-      split_includes = Array(includes).map{|inc| inc.to_s.split('.')}
+      split_includes = Array(includes).map do |inc|
+        if inc.is_a? Hash
+          flatten_hash(inc)
+        else
+          inc.to_s.split('.')
+        end
+      end
+
       if split_includes.blank?
         return first_include
       end
@@ -29,6 +36,19 @@ module JsonApi
       end
 
       first_include
+    end
+
+    # Recursive function to convert a hash into an array of arrays of strings
+    # Ex: { foo: { bar: :baz } } flattens to [['foo', 'bar', 'baz']]
+    def self.flatten_hash(inc, ary = [])
+      inc.to_a.flat_map do |a|
+        if a.last.is_a? Hash
+          ary << a.first.to_s
+          flatten_hash(a.last, ary)
+        else
+          ary + a.map(&:to_s)
+        end
+      end
     end
 
     def has_name?(name)

--- a/lib/json_api_ruby/version.rb
+++ b/lib/json_api_ruby/version.rb
@@ -1,3 +1,3 @@
 module JsonApi
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/spec/json_api_ruby/includes_spec.rb
+++ b/spec/json_api_ruby/includes_spec.rb
@@ -33,4 +33,19 @@ describe JsonApi::Includes do
       specify { expect(parsed_includes.next.next.includes).to eq ['thingthree', 'thingfive'] }
     end
   end
+
+  describe 'flattened hash' do
+    subject(:flattened) do
+      described_class.flatten_hash(hash)
+    end
+
+    context 'given the deeply nested hash { foo: { bar: :baz } }' do
+      let(:hash) do
+        { foo: { bar: :baz } }
+      end
+      let(:expected_ary) { ['foo', 'bar', 'baz'] }
+
+      it { expect(flattened).to eq expected_ary }
+    end
+  end
 end

--- a/spec/json_api_ruby/serializer_spec.rb
+++ b/spec/json_api_ruby/serializer_spec.rb
@@ -48,12 +48,31 @@ RSpec.describe JsonApi::Serializer do
         expect(found_document).to be_present
       end
 
-      it 'supports nested includes' do
-        serialized = JsonApi.serialize(person, include: ['articles.comments'])
-        comments = serialized['included'].select do |document|
-          document['type'] == 'comments'
+      context 'deeply nested' do
+        describe 'requested included data' do
+          subject(:comments) do
+            serialized['included'].select do |document|
+              document['type'] == 'comments'
+            end
+          end
+          subject(:author) do
+            serialized['included'].detect do |document|
+              document['type'] == 'people'
+            end
+          end
+
+          context 'with string arguments' do
+            let(:serialized) { JsonApi.serialize(person, include: ['articles.comments.author']) }
+            it { expect(comments).to be_present }
+            it { expect(author).to be_present }
+          end
+
+          context 'with hash arguments' do
+            let(:serialized) { JsonApi.serialize(person, include: [{ articles: { comments: :author } }]) }
+            it { expect(comments).to be_present }
+            it { expect(author).to be_present }
+          end
         end
-        expect(comments).to be_present
       end
     end
   end


### PR DESCRIPTION
This allows us to pass the `include` arg in the same structure as is
expected by ActiveRecord::QueryMethods#includes