### PR TITLE
Fixes an issue with complex includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.4.4
+Fixed an issue with complex includes
+
 0.4.3
 Removed the constraint on activesupport 3. Should be >= 3 not ~> 3
 

--- a/lib/json_api_ruby/version.rb
+++ b/lib/json_api_ruby/version.rb
@@ -1,3 +1,3 @@
 module JsonApi
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/spec/json_api_ruby/includes_spec.rb
+++ b/spec/json_api_ruby/includes_spec.rb
@@ -25,10 +25,10 @@ describe JsonApi::Includes do
 
     context 'complex includes' do
       subject(:parsed_includes) do
-        described_class.parse_includes(['thingone.thingtwo.thingthree', 'thingone.thingfour', 'thingone.thingtwo.thingfive', 'thingsix.thingseven'])
+        described_class.parse_includes(['thingeight', 'thingnine', 'thingone.thingtwo.thingthree', 'thingone.thingfour', 'thingone.thingtwo.thingfive', 'thingsix.thingseven'])
       end
 
-      specify { expect(parsed_includes.includes).to eq ['thingone', 'thingsix'] }
+      specify { expect(parsed_includes.includes).to eq ['thingeight', 'thingnine', 'thingone', 'thingsix'] }
       specify { expect(parsed_includes.next.includes).to eq ['thingtwo', 'thingfour', 'thingseven'] }
       specify { expect(parsed_includes.next.next.includes).to eq ['thingthree', 'thingfive'] }
     end


### PR DESCRIPTION
With an includes structure that looks like
"one,two,one.three,one.four,one.five.six" only the first included
resource was getting included